### PR TITLE
Step1 미션 제출합니다

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="Embedded JDK" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# 2주차 미션
+## 🎲  1단계
+### GithubProfileRepository
+1. 입력된 이름에 대한 Github Profile이 반환된다.
+2. Github Profile을 Local DB에 저장한다

--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 ### GithubProfileRepository
 1. 입력된 이름에 대한 Github Profile이 반환된다.
 2. Github Profile을 Local DB에 저장한다
+
+### DefaultGithubProfileRepository
+1. GithubProfile이 Local DB에 없으면, Remote의 getGithubProfile()과 Local의 saveGithubProfile이 호출된다
+2. userName이 Local DB에 존재하면 GithubProfile을 반환한다
+3. GithubProfile을 LocalDB에 저장할 때 LocalGithubProfileSource의 saveGithubProfile 메소드가 호출된다

--- a/app/src/test/java/com/malibin/study/github/data/repository/DefaultGithubProfileRepositoryTest.kt
+++ b/app/src/test/java/com/malibin/study/github/data/repository/DefaultGithubProfileRepositoryTest.kt
@@ -124,19 +124,17 @@ internal class DefaultGithubProfileRepositoryTest {
             )
             defaultGithubProfileRepository.saveGithubProfile(gitHubProfile)
             //then
-            assertAll(
-                {
-                    coVerify(exactly = 1) {
-                        fakeLocalGithubProfileSource.saveGithubProfile(
-                            gitHubProfile
-                        )
-                    }
-                }
-            )
-        }
 
+            coVerify(exactly = 1) {
+                fakeLocalGithubProfileSource.saveGithubProfile(
+                    gitHubProfile
+                )
+            }
+        }
     }
 
 }
+
+
 
 

--- a/app/src/test/java/com/malibin/study/github/data/repository/DefaultGithubProfileRepositoryTest.kt
+++ b/app/src/test/java/com/malibin/study/github/data/repository/DefaultGithubProfileRepositoryTest.kt
@@ -26,13 +26,13 @@ internal class DefaultGithubProfileRepositoryTest {
             fakeLocalGithubProfileSource, fakeRemoteGithubProfileSource
         )
         gitHubProfile = GithubProfile(
-            1L,
-            "name1",
-            "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
-            "name1",
-            "Hello",
-            1,
-            1
+            id = 1L,
+            userName = "name1",
+            avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+            name = "name1",
+            bio = "Hello",
+            followersCount = 1,
+            followingCount = 1
         )
     }
 

--- a/app/src/test/java/com/malibin/study/github/data/repository/DefaultGithubProfileRepositoryTest.kt
+++ b/app/src/test/java/com/malibin/study/github/data/repository/DefaultGithubProfileRepositoryTest.kt
@@ -1,0 +1,142 @@
+package com.malibin.study.github.data.repository
+
+import com.google.common.truth.Truth.assertThat
+import com.malibin.study.github.data.source.GithubProfileSource
+import com.malibin.study.github.domain.profile.GithubProfile
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+internal class DefaultGithubProfileRepositoryTest {
+
+
+    @Test
+    fun `GithubProfile이 Local DB에 없으면, Remote의 getGithubProfile()과 Local의 saveGithubProfile이 호출된다`() {
+        runBlocking {
+            //given
+            val fakeRemoteGithubProfileSource = mockk<GithubProfileSource>()
+            val fakeLocalGithubProfileSource = mockk<GithubProfileSource>()
+            val defaultGithubProfileRepository = DefaultGithubProfileRepository(
+                fakeLocalGithubProfileSource, fakeRemoteGithubProfileSource
+            )
+            val gitHubProfile = GithubProfile(
+                1L,
+                "name1",
+                "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+                "name1",
+                "Hello",
+                1,
+                1
+            )
+            //when
+            coEvery { fakeLocalGithubProfileSource.getGithubProfile("name1") } returns Result.failure(
+                IllegalArgumentException("cannot find githubProfile of userName(name1)")
+            )
+            coEvery { fakeRemoteGithubProfileSource.getGithubProfile("name1") } returns Result.success(
+                gitHubProfile
+            )
+            coEvery { fakeLocalGithubProfileSource.saveGithubProfile(gitHubProfile) } returns Result.success(
+                Unit
+            )
+
+            val actualResult = defaultGithubProfileRepository.getGithubProfile("name1")
+
+            //then
+            assertAll(
+                { coVerify(exactly = 1) { fakeLocalGithubProfileSource.getGithubProfile("name1") } },
+                { coVerify(exactly = 1) { fakeRemoteGithubProfileSource.getGithubProfile("name1") } },
+                {
+                    coVerify(exactly = 1) {
+                        fakeLocalGithubProfileSource.saveGithubProfile(
+                            gitHubProfile
+                        )
+                    }
+                },
+                { assertThat(actualResult).isEqualTo(Result.success(gitHubProfile)) },
+            )
+            confirmVerified(fakeLocalGithubProfileSource, fakeRemoteGithubProfileSource)
+        }
+    }
+
+
+    @Test
+    fun `userName이 Local DB에 존재하면 GithubProfile을 반환한다`() {
+        runBlocking {
+            //given
+            val fakeRemoteGithubProfileSource = mockk<GithubProfileSource>()
+            val fakeLocalGithubProfileSource = mockk<GithubProfileSource>()
+            val defaultGithubProfileRepository = DefaultGithubProfileRepository(
+                fakeLocalGithubProfileSource, fakeRemoteGithubProfileSource
+            )
+            val gitHubProfile = GithubProfile(
+                1L,
+                "name1",
+                "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+                "name1",
+                "Hello",
+                1,
+                1
+            )
+            //when
+            coEvery { fakeLocalGithubProfileSource.getGithubProfile("name1") } returns Result.success(
+                gitHubProfile
+            )
+            val actualResult = defaultGithubProfileRepository.getGithubProfile("name1")
+            //then
+            assertAll(
+                { assertThat(actualResult).isEqualTo(Result.success(gitHubProfile)) },
+                {
+                    coVerify(exactly = 1) {
+                        fakeLocalGithubProfileSource.getGithubProfile(
+                            "name1"
+                        )
+                    }
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `GithubProfile을 LocalDB에 저장할 때 LocalGithubProfileSource의 saveGithubProfile 메소드가 호출된다`() {
+        runBlocking {
+            //given
+            val fakeRemoteGithubProfileSource = mockk<GithubProfileSource>()
+            val fakeLocalGithubProfileSource = mockk<GithubProfileSource>()
+            val defaultGithubProfileRepository = DefaultGithubProfileRepository(
+                fakeLocalGithubProfileSource, fakeRemoteGithubProfileSource
+            )
+            val gitHubProfile = GithubProfile(
+                1L,
+                "name1",
+                "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+                "name1",
+                "Hello",
+                1,
+                1
+            )
+            //when
+            coEvery { fakeLocalGithubProfileSource.saveGithubProfile(gitHubProfile) } returns Result.success(
+                Unit
+            )
+            defaultGithubProfileRepository.saveGithubProfile(gitHubProfile)
+            //then
+            assertAll(
+                {
+                    coVerify(exactly = 1) {
+                        fakeLocalGithubProfileSource.saveGithubProfile(
+                            gitHubProfile
+                        )
+                    }
+                }
+            )
+        }
+
+    }
+
+}
+
+

--- a/app/src/test/java/com/malibin/study/github/domain/repository/GithubProfileRepositoryTest.kt
+++ b/app/src/test/java/com/malibin/study/github/domain/repository/GithubProfileRepositoryTest.kt
@@ -22,15 +22,14 @@ internal class GithubProfileRepositoryTest {
                 1,
                 1
             )
-            coEvery { fakeGithubProfileRepository.getGithubProfile("name") } returns runCatching {
+            coEvery { fakeGithubProfileRepository.getGithubProfile("name") } returns Result.success(
                 gitHubProfile
-            }
+            )
+
             //when
             val actualProfile = fakeGithubProfileRepository.getGithubProfile("name")
             //then
-            assertThat(actualProfile).isEqualTo(runCatching {
-                gitHubProfile
-            })
+            assertThat(actualProfile).isEqualTo(Result.success(gitHubProfile))
         }
     }
 
@@ -52,13 +51,12 @@ internal class GithubProfileRepositoryTest {
                 fakeGithubProfileRepository.saveGithubProfile(
                     gitHubProfile
                 )
-            } returns gitHubProfile.runCatching { }
+            } returns Result.success(Unit)
             //when
             val actualResult =
                 fakeGithubProfileRepository.saveGithubProfile(gitHubProfile)
             //then
-            assertThat(actualResult).isEqualTo(runCatching {
-            })
+            assertThat(actualResult).isEqualTo(Result.success(Unit))
         }
     }
 }

--- a/app/src/test/java/com/malibin/study/github/domain/repository/GithubProfileRepositoryTest.kt
+++ b/app/src/test/java/com/malibin/study/github/domain/repository/GithubProfileRepositoryTest.kt
@@ -9,54 +9,51 @@ import org.junit.jupiter.api.Test
 
 internal class GithubProfileRepositoryTest {
     @Test
-    fun `입력된 이름에 대한 Github Profile이 반환된다`() {
-        runBlocking {
-            //given
-            val fakeGithubProfileRepository = mockk<GithubProfileRepository>()
-            val gitHubProfile = GithubProfile(
-                1L,
-                "name1",
-                "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
-                "name1",
-                "Hello",
-                1,
-                1
-            )
-            coEvery { fakeGithubProfileRepository.getGithubProfile("name") } returns Result.success(
-                gitHubProfile
-            )
+    fun `입력된 이름에 대한 Github Profile이 반환된다`() = runBlocking {
+        //given
+        val fakeGithubProfileRepository = mockk<GithubProfileRepository>()
+        val gitHubProfile = GithubProfile(
+            1L,
+            "name1",
+            "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+            "name1",
+            "Hello",
+            1,
+            1
+        )
+        coEvery { fakeGithubProfileRepository.getGithubProfile("name") } returns Result.success(
+            gitHubProfile
+        )
 
-            //when
-            val actualProfile = fakeGithubProfileRepository.getGithubProfile("name")
-            //then
-            assertThat(actualProfile).isEqualTo(Result.success(gitHubProfile))
-        }
+        //when
+        val actualProfile = fakeGithubProfileRepository.getGithubProfile("name")
+        //then
+        assertThat(actualProfile).isEqualTo(Result.success(gitHubProfile))
     }
+
 
     @Test
-    fun `Github Profile을 Local DB에 저장한다`() {
-        runBlocking {
-            //given
-            val fakeGithubProfileRepository = mockk<GithubProfileRepository>()
-            val gitHubProfile = GithubProfile(
-                1L,
-                "name1",
-                "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
-                "name1",
-                "Hello",
-                1,
-                1
+    fun `Github Profile을 Local DB에 저장한다`() = runBlocking {
+        //given
+        val fakeGithubProfileRepository = mockk<GithubProfileRepository>()
+        val gitHubProfile = GithubProfile(
+            1L,
+            "name1",
+            "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+            "name1",
+            "Hello",
+            1,
+            1
+        )
+        coEvery {
+            fakeGithubProfileRepository.saveGithubProfile(
+                gitHubProfile
             )
-            coEvery {
-                fakeGithubProfileRepository.saveGithubProfile(
-                    gitHubProfile
-                )
-            } returns Result.success(Unit)
-            //when
-            val actualResult =
-                fakeGithubProfileRepository.saveGithubProfile(gitHubProfile)
-            //then
-            assertThat(actualResult).isEqualTo(Result.success(Unit))
-        }
+        } returns Result.success(Unit)
+        //when
+        val actualResult = fakeGithubProfileRepository.saveGithubProfile(gitHubProfile)
+        //then
+        assertThat(actualResult).isEqualTo(Result.success(Unit))
     }
+
 }

--- a/app/src/test/java/com/malibin/study/github/domain/repository/GithubProfileRepositoryTest.kt
+++ b/app/src/test/java/com/malibin/study/github/domain/repository/GithubProfileRepositoryTest.kt
@@ -1,0 +1,64 @@
+package com.malibin.study.github.domain.repository
+
+import com.google.common.truth.Truth.assertThat
+import com.malibin.study.github.domain.profile.GithubProfile
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+
+internal class GithubProfileRepositoryTest {
+    @Test
+    fun `입력된 이름에 대한 Github Profile이 반환된다`() {
+        runBlocking {
+            //given
+            val fakeGithubProfileRepository = mockk<GithubProfileRepository>()
+            val gitHubProfile = GithubProfile(
+                1L,
+                "name1",
+                "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+                "name1",
+                "Hello",
+                1,
+                1
+            )
+            coEvery { fakeGithubProfileRepository.getGithubProfile("name") } returns runCatching {
+                gitHubProfile
+            }
+            //when
+            val actualProfile = fakeGithubProfileRepository.getGithubProfile("name")
+            //then
+            assertThat(actualProfile).isEqualTo(runCatching {
+                gitHubProfile
+            })
+        }
+    }
+
+    @Test
+    fun `Github Profile을 Local DB에 저장한다`() {
+        runBlocking {
+            //given
+            val fakeGithubProfileRepository = mockk<GithubProfileRepository>()
+            val gitHubProfile = GithubProfile(
+                1L,
+                "name1",
+                "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+                "name1",
+                "Hello",
+                1,
+                1
+            )
+            coEvery {
+                fakeGithubProfileRepository.saveGithubProfile(
+                    gitHubProfile
+                )
+            } returns gitHubProfile.runCatching { }
+            //when
+            val actualResult =
+                fakeGithubProfileRepository.saveGithubProfile(gitHubProfile)
+            //then
+            assertThat(actualResult).isEqualTo(runCatching {
+            })
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.4.0' apply false
-    id 'com.android.library' version '7.4.0' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'com.android.library' version '7.3.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
 }


### PR DESCRIPTION
[GithubProfileRepositoryTest]

[테스트 케이스]
`입력된 이름에 대한 Github Profile이 반환된다`
`Github Profile을 Local DB에 저장한다`

[개요]
mockk을 활용하여 가짜 GithubProfileRepository 객체를 만들어 해결했습니다.
테스트 대상 메소드인 get,saveGithubProfile이 suspend 메소드인 점을 고려하여 
runBlocking으로 전체를 감싸준 후에 coEvery와 returns메소드로 특정한 값이 나오도록 하였습니다.

[의문점]
GithubProfileRepository 인터페이스만을 mock으로 테스트 하는 것이 맞을까요?
![image](https://user-images.githubusercontent.com/70442964/216809574-68a4e168-0d3e-4733-8415-8952a46c0c29.png)
2주차 미션 가이드에는 class로 적혀있어서, GithubProfileRepository 인터페이스만을 테스트하면 되는 것인지,
GithubProfileRepository 인터페이스를 상속 받은 클래스 DefaultGithubProfileRepository에 대해서도 테스트 해야하는 것인지가 헷갈립니다.
======> DefaultGitHubProfileRepository를 테스트하는 거였군요!! 확인했습니다~🤣

[DefaultGithubProfileRepositoryTest]

[테스트 케이스]
`GithubProfile이 Local DB에 없으면, Remote의 getGithubProfile()과 Local의 saveGithubProfile이 호출된다`
`userName이 Local DB에 존재하면 GithubProfile을 반환한다`
`GithubProfile을 LocalDB에 저장할 때 LocalGithubProfileSource의 saveGithubProfile 메소드가 호출된다`

[개요]
# 공통 사항
DefaultGithubProfileRepository객체를 생성하기 위해 필요한 localGithubProfileSource와 remoteGithubProfileSource를
mockk을 활용하여 만들었습니다.
테스트 대상 메소드가 suspend 메소드인 점을 고려하여 runBlocking으로 전체를 감싸준 후에 coEvery와 returns메소드로 의도된 값을 반환하도록 하였습니다.

`GithubProfile이 Local DB에 없으면, Remote의 getGithubProfile()과 Local의 saveGithubProfile이 호출된다`
Local DB에 GithubProfile이 없는 상황을 가정하여, 이후에 호출되어야 할 메소드들이 정상 호출 되었는지를 coVerify를 활용하여 검증했습니다.
Local과 Remote mock 객체가 verify 되었는지를 확인하기 위해 confirmVerified 메소드를 호출하였습니다.

`userName이 Local DB에 존재하면 GithubProfile을 반환한다`
coEvery로 fakeLocalGithubProfileSource.getGithubProfile("name1")이 Result.success(gitHubProfile)을 반환하도록 하고,
assertThat으로 결과를 확인하였습니다.
coVeryfy를 활용하여 LocalGithubProfileSource의 getGithubProfile이 호출되었는지를 검증하였습니다.

`GithubProfile을 LocalDB에 저장할 때 LocalGithubProfileSource의 saveGithubProfile 메소드가 호출된다`
DefaultGithubProfileRepository의 saveGithubProfile 메소드 호출 시, fakeRemoteGithubProfileSource의 saveGithubProfile이
정상적으로 호출되는 지를 coVerify로 검증하였습니다.