### PR TITLE
Step2 미션 제출합니다

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 ## 🎲  1단계
 ### GithubProfileRepository
 1. 입력된 이름에 대한 Github Profile이 반환된다.
-2. Github Profile을 Local DB에 저장한다
+2. Github Profile을 Local DB에 저장한다.
 
 ### DefaultGithubProfileRepository
-1. GithubProfile이 Local DB에 없으면, Remote의 getGithubProfile()과 Local의 saveGithubProfile이 호출된다
-2. userName이 Local DB에 존재하면 GithubProfile을 반환한다
-3. GithubProfile을 LocalDB에 저장할 때 LocalGithubProfileSource의 saveGithubProfile 메소드가 호출된다
+1. GithubProfile이 Local DB에 없으면, Remote의 getGithubProfile()과 Local의 saveGithubProfile이 호출된다.
+2. userName이 Local DB에 존재하면 GithubProfile을 반환한다.
+3. GithubProfile을 LocalDB에 저장할 때 LocalGithubProfileSource의 saveGithubProfile 메소드가 호출된다.
+
+## 🎲  2단계
+1. loadGithubProfile 메소드 호출 성공 시 GithubProfile을 가져온다.
+2. loadGithubProfile 메소드 호출 실패 시 isError의 value 가 True가 된다.

--- a/app/src/test/java/com/malibin/study/github/data/repository/DefaultGithubProfileRepositoryTest.kt
+++ b/app/src/test/java/com/malibin/study/github/data/repository/DefaultGithubProfileRepositoryTest.kt
@@ -19,20 +19,11 @@ internal class DefaultGithubProfileRepositoryTest {
     lateinit var gitHubProfile: GithubProfile
 
     @BeforeEach
-    fun `setUp`() {
+    fun setUp() {
         fakeRemoteGithubProfileSource = mockk()
         fakeLocalGithubProfileSource = mockk()
         defaultGithubProfileRepository = DefaultGithubProfileRepository(
             fakeLocalGithubProfileSource, fakeRemoteGithubProfileSource
-        )
-        gitHubProfile = GithubProfile(
-            id = 1L,
-            userName = "name1",
-            avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
-            name = "name1",
-            bio = "Hello",
-            followersCount = 1,
-            followingCount = 1
         )
     }
 
@@ -40,27 +31,39 @@ internal class DefaultGithubProfileRepositoryTest {
     fun `GithubProfile이 Local DB에 없으면, Remote의 getGithubProfile()과 Local의 saveGithubProfile이 호출된다`() =
         runBlocking {
             //given
-            coEvery { fakeLocalGithubProfileSource.getGithubProfile("name1") } returns Result.failure(
-                IllegalArgumentException("cannot find githubProfile of userName(name1)")
+            gitHubProfile = GithubProfile(
+                id = 1L,
+                userName = "name1",
+                avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+                name = "name1",
+                bio = "Hello",
+                followersCount = 1,
+                followingCount = 1
             )
-            coEvery { fakeRemoteGithubProfileSource.getGithubProfile("name1") } returns Result.success(
-                gitHubProfile
-            )
-            coEvery { fakeLocalGithubProfileSource.saveGithubProfile(gitHubProfile) } returns Result.success(
-                Unit
-            )
+
+            coEvery {
+                fakeLocalGithubProfileSource.getGithubProfile("name1")
+            } returns Result.failure(IllegalArgumentException("cannot find githubProfile of userName(name1)"))
+            coEvery {
+                fakeRemoteGithubProfileSource.getGithubProfile("name1")
+            } returns Result.success(gitHubProfile)
+            coEvery {
+                fakeLocalGithubProfileSource.saveGithubProfile(gitHubProfile)
+            } returns Result.success(Unit)
             //when
             val actualResult = defaultGithubProfileRepository.getGithubProfile("name1")
 
             //then
             assertAll(
-                { coVerify(exactly = 1) { fakeLocalGithubProfileSource.getGithubProfile("name1") } },
-                { coVerify(exactly = 1) { fakeRemoteGithubProfileSource.getGithubProfile("name1") } },
+                { coVerify(exactly = 1) {
+                    fakeLocalGithubProfileSource.getGithubProfile("name1")
+                } },
+                { coVerify(exactly = 1) {
+                    fakeRemoteGithubProfileSource.getGithubProfile("name1")
+                } },
                 {
                     coVerify(exactly = 1) {
-                        fakeLocalGithubProfileSource.saveGithubProfile(
-                            gitHubProfile
-                        )
+                        fakeLocalGithubProfileSource.saveGithubProfile(gitHubProfile)
                     }
                 },
                 { assertThat(actualResult.getOrNull()).isEqualTo(gitHubProfile) },
@@ -73,26 +76,42 @@ internal class DefaultGithubProfileRepositoryTest {
     @Test
     fun `userName이 Local DB에 존재하면 GithubProfile을 반환한다`() = runBlocking {
         //given
+        gitHubProfile = GithubProfile(
+            id = 1L,
+            userName = "name1",
+            avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+            name = "name1",
+            bio = "Hello",
+            followersCount = 1,
+            followingCount = 1
+        )
+
         coEvery { fakeLocalGithubProfileSource.getGithubProfile("name1") } returns Result.success(
             gitHubProfile
         )
         //when
         val actualResult = defaultGithubProfileRepository.getGithubProfile("name1")
         //then
-        assertAll({ assertThat(actualResult).isEqualTo(Result.success(gitHubProfile)) }, {
-            coVerify(exactly = 1) {
-                fakeLocalGithubProfileSource.getGithubProfile(
-                    "name1"
-                )
-            }
-        })
-
+        assertAll(
+            { assertThat(actualResult).isEqualTo(Result.success(gitHubProfile))},
+            { coVerify(exactly = 1) { fakeLocalGithubProfileSource.getGithubProfile("name1") } }
+        )
     }
 
     @Test
     fun `GithubProfile을 LocalDB에 저장할 때 LocalGithubProfileSource의 saveGithubProfile 메소드가 호출된다`() =
         runBlocking {
             //given
+            gitHubProfile = GithubProfile(
+                id = 1L,
+                userName = "name1",
+                avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+                name = "name1",
+                bio = "Hello",
+                followersCount = 1,
+                followingCount = 1
+            )
+
             coEvery { fakeLocalGithubProfileSource.saveGithubProfile(gitHubProfile) } returns Result.success(
                 Unit
             )

--- a/app/src/test/java/com/malibin/study/github/domain/repository/GithubProfileRepositoryTest.kt
+++ b/app/src/test/java/com/malibin/study/github/domain/repository/GithubProfileRepositoryTest.kt
@@ -13,13 +13,13 @@ internal class GithubProfileRepositoryTest {
         //given
         val fakeGithubProfileRepository = mockk<GithubProfileRepository>()
         val gitHubProfile = GithubProfile(
-            1L,
-            "name1",
-            "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
-            "name1",
-            "Hello",
-            1,
-            1
+            id = 1L,
+            userName = "name1",
+            avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+            name = "name1",
+            bio = "Hello",
+            followersCount = 1,
+            followingCount = 1
         )
         coEvery { fakeGithubProfileRepository.getGithubProfile("name") } returns Result.success(
             gitHubProfile
@@ -37,13 +37,13 @@ internal class GithubProfileRepositoryTest {
         //given
         val fakeGithubProfileRepository = mockk<GithubProfileRepository>()
         val gitHubProfile = GithubProfile(
-            1L,
-            "name1",
-            "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
-            "name1",
-            "Hello",
-            1,
-            1
+            id = 1L,
+            userName = "name1",
+            avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+            name = "name1",
+            bio = "Hello",
+            followersCount = 1,
+            followingCount = 1
         )
         coEvery {
             fakeGithubProfileRepository.saveGithubProfile(

--- a/app/src/test/java/com/malibin/study/github/presentation/MainViewModelTest.kt
+++ b/app/src/test/java/com/malibin/study/github/presentation/MainViewModelTest.kt
@@ -1,21 +1,77 @@
 package com.malibin.study.github.presentation
 
+import com.google.common.truth.Truth.assertThat
+import com.malibin.study.github.domain.profile.GithubProfile
+import com.malibin.study.github.domain.repository.GithubProfileRepository
 import com.malibin.study.github.utils.InstantTaskExecutorExtension
 import com.malibin.study.github.utils.MainCoroutineExtension
+import com.malibin.study.github.utils.getOrAwaitValue
+import io.mockk.*
+import io.mockk.InternalPlatformDsl.toStr
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class MainViewModelTest {
 
     companion object {
-        @JvmField
+        @JvmStatic
         @RegisterExtension
         val instantTaskExecutorExtension = InstantTaskExecutorExtension()
 
-        @JvmField
+        @JvmStatic
         @RegisterExtension
-        val coroutineExtension = MainCoroutineExtension()
+        val mainCoroutineExtension = MainCoroutineExtension()
     }
 
+    private lateinit var fakeMainViewModel: MainViewModel
+    private lateinit var fakeProfileRepository: GithubProfileRepository
+
+    @BeforeEach
+    fun setUp() {
+        fakeProfileRepository = mockk(relaxed = true)
+        fakeMainViewModel = MainViewModel(fakeProfileRepository)
+    }
+
+    @Test
+    fun `loadGithubProfile 메소드 호출 성공 시 GithubProfile을 가져온다`() = runBlocking {
+        //given
+        val expectedGithubProfile = GithubProfile(
+                id = 1L,
+                userName = "name1",
+                avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+                name = "name1",
+                bio = "Hello",
+                followersCount = 1,
+                followingCount = 1
+            )
+
+        //when
+        coEvery {
+            fakeProfileRepository.getGithubProfile(any())
+        } returns Result.success(expectedGithubProfile)
+        fakeMainViewModel.loadGithubProfile()
+
+            //then
+        assertAll(
+            { coVerify(exactly = 1) { fakeProfileRepository.getGithubProfile(any())}},
+            { assertThat(fakeMainViewModel.githubProfile.getOrAwaitValue()).isEqualTo(expectedGithubProfile)}
+        )
+    }
+    @Test
+    fun `loadGithubProfile 메소드 호출 실패 시 isError의 value 가 True가 된다`(){
+        coEvery {
+            fakeProfileRepository.getGithubProfile(any())
+        } returns Result.failure(IllegalArgumentException())
+        fakeMainViewModel.loadGithubProfile()
+        assertAll(
+            { coVerify(exactly = 1) { fakeProfileRepository.getGithubProfile(any())}},
+            { assertThat(fakeMainViewModel.isError.getOrAwaitValue()).isTrue() }
+        )
+    }
 }

--- a/app/src/test/java/com/malibin/study/github/presentation/MainViewModelTest.kt
+++ b/app/src/test/java/com/malibin/study/github/presentation/MainViewModelTest.kt
@@ -7,13 +7,11 @@ import com.malibin.study.github.utils.InstantTaskExecutorExtension
 import com.malibin.study.github.utils.MainCoroutineExtension
 import com.malibin.study.github.utils.getOrAwaitValue
 import io.mockk.*
-import io.mockk.InternalPlatformDsl.toStr
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -42,35 +40,43 @@ internal class MainViewModelTest {
     fun `loadGithubProfile 메소드 호출 성공 시 GithubProfile을 가져온다`() = runBlocking {
         //given
         val expectedGithubProfile = GithubProfile(
-                id = 1L,
-                userName = "name1",
-                avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
-                name = "name1",
-                bio = "Hello",
-                followersCount = 1,
-                followingCount = 1
-            )
-
-        //when
+            id = 1L,
+            userName = "name1",
+            avatarUrl = "https://www.linkpicture.com/view.php?img=LPic63df5f35265bb1785508137",
+            name = "name1",
+            bio = "Hello",
+            followersCount = 1,
+            followingCount = 1
+        )
         coEvery {
             fakeProfileRepository.getGithubProfile(any())
         } returns Result.success(expectedGithubProfile)
+
+        //when
         fakeMainViewModel.loadGithubProfile()
 
-            //then
+        //then
         assertAll(
-            { coVerify(exactly = 1) { fakeProfileRepository.getGithubProfile(any())}},
-            { assertThat(fakeMainViewModel.githubProfile.getOrAwaitValue()).isEqualTo(expectedGithubProfile)}
+            { coVerify(exactly = 1) { fakeProfileRepository.getGithubProfile(any()) } },
+            {
+                assertThat(fakeMainViewModel.githubProfile.getOrAwaitValue()).isEqualTo(
+                    expectedGithubProfile
+                )
+            }
         )
     }
+
     @Test
-    fun `loadGithubProfile 메소드 호출 실패 시 isError의 value 가 True가 된다`(){
+    fun `loadGithubProfile 메소드 호출 실패 시 isError의 value 가 True가 된다`() {
+        //given
         coEvery {
             fakeProfileRepository.getGithubProfile(any())
         } returns Result.failure(IllegalArgumentException())
+        //when
         fakeMainViewModel.loadGithubProfile()
+        //then
         assertAll(
-            { coVerify(exactly = 1) { fakeProfileRepository.getGithubProfile(any())}},
+            { coVerify(exactly = 1) { fakeProfileRepository.getGithubProfile(any()) } },
             { assertThat(fakeMainViewModel.isError.getOrAwaitValue()).isTrue() }
         )
     }


### PR DESCRIPTION
[MainViewModelTest]

[테스트 케이스]
`loadGithubProfile 메소드 호출 성공 시 GithubProfile을 가져온다`
`loadGithubProfile 메소드 호출 실패 시 isError의 value 가 True가 된다`

[개요]
MainViewModelTest의 assert구문이 MainViewModel의 함수가 시작하지도 않았음에도 끝나버리는 문제를 막기 위해, MainViewModel과의 코루틴 스코프를 맞춰주기 위한 MainCoroutineExtension을 등록했습니다.
@BeforeEach를 사용하기 위해 InstantTaskExecutorExtension을 companion object에 등록한 후,
@BeforeEach를 사용하여 ProfileRepository의 mockk 객체를 만들고, 이를 활용해 MainViewModel 객체도 만들었습니다.
라이브 데이터(githubProfile, isError)의 value를 //then 구문에서 검사해주기 위해 getOrAwaitValue() 메소드를 사용하였습니다.
